### PR TITLE
 add punycode homograph identification

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,8 +170,8 @@
   </dependencies>
 
   <properties>
-    <maven.compiler.source>1.6</maven.compiler.source>
-    <maven.compiler.target>1.6</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
 
     <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/org/owasp/url/BUILD
+++ b/src/main/java/org/owasp/url/BUILD
@@ -3,8 +3,8 @@ package(
 )
 
 JAVAC_OPTS = [
-    "-target", "6",
-    "-source", "6",
+    "-target", "8",
+    "-source", "8",
     ]
 
 

--- a/src/main/java/org/owasp/url/Classification.java
+++ b/src/main/java/org/owasp/url/Classification.java
@@ -36,7 +36,7 @@ public enum Classification {
   NOT_A_MATCH,
   /** The URL input does match the classifier. */
   MATCH,
-  /** THe URL input is structurally invalid. */
+  /** The URL input is structurally invalid. */
   INVALID,
   ;
 

--- a/src/main/java/org/owasp/url/PunycodeIdentifier.java
+++ b/src/main/java/org/owasp/url/PunycodeIdentifier.java
@@ -1,0 +1,5 @@
+package org.owasp.url;
+
+public interface PunycodeIdentifier {
+  boolean isPotentialHomograph(String name);
+}

--- a/src/main/java/org/owasp/url/PunycodeIdentifierBuilder.java
+++ b/src/main/java/org/owasp/url/PunycodeIdentifierBuilder.java
@@ -1,0 +1,124 @@
+// Copyright (c) 2019, Trent Miller
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+// Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+// Neither the name of the OWASP nor the names of its contributors may
+// be used to endorse or promote products derived from this software
+// without specific prior written permission.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+package org.owasp.url;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static java.lang.Character.UnicodeScript.*;
+
+/**
+ * A builder for {@link PunycodeIdentifier}s.
+ */
+public final class PunycodeIdentifierBuilder {
+
+  public static final PunycodeIdentifier DEFAULT
+      = new PunycodeIdentifierImpl();
+
+  /**
+   * Builds a punycode identifier.
+   */
+  public PunycodeIdentifier build() {
+    return new PunycodeIdentifierImpl();
+  }
+}
+
+/**
+ * Checks for homographs via combinations of unicode scripts
+ * Approximates the mixed-script detection portion of Mozilla's punycode detection algorithm outlined at https://wiki.mozilla.org/IDN_Display_Algorithm
+ * Does not yet incorporate individual character checking as recommended by https://tools.ietf.org/html/rfc5892
+ * Reference: https://www.unicode.org/reports/tr39
+ */
+final class PunycodeIdentifierImpl implements PunycodeIdentifier {
+  private final List<Character.UnicodeScript> ignorableScripts = Arrays.asList(COMMON, INHERITED);
+  private final List<Character.UnicodeScript> uniqueScripts = Arrays.asList(CYRILLIC, GREEK);
+  private final List<List<Character.UnicodeScript>> hanScripts = Arrays.asList(
+      Arrays.asList(LATIN, HAN, HIRAGANA, KATAKANA),
+      Arrays.asList(LATIN, HAN, BOPOMOFO),
+      Arrays.asList(LATIN, HAN, HANGUL)
+  );
+
+  @Override
+  public boolean isPotentialHomograph(String name) {
+    final String[] parts = name.split("\\.");
+
+    if (parts.length > 0) { // evaluate sub domains, domain, and tld independently
+      for (String part : parts) {
+        if (isPotentialHomographPart(part)) {
+          return true;
+        }
+      }
+
+      return false;
+    } else {
+      return isPotentialHomographPart(name);
+    }
+  }
+
+  private boolean isPotentialHomographPart(String part) {
+    final List<Character.UnicodeScript> scripts = new ArrayList<>();
+
+    for (int i = 0; i < part.length(); ) {
+      int codepoint = part.codePointAt(i);
+      final Character.UnicodeScript script = Character.UnicodeScript.of(codepoint);
+
+      if (!ignorableScripts.contains(script) && !scripts.contains(script)) {
+        scripts.add(script);
+
+        if (scripts.size() > 1 && isInvalidMix(scripts)) {
+          return true;
+        }
+      }
+
+      i += Character.charCount(codepoint);
+    }
+
+    return false;
+  }
+
+  private boolean isInvalidMix(List<Character.UnicodeScript> scripts) {
+    return mixedGreekOrCyrillic(scripts) || (!isValidLatin(scripts) && !isValidHan(scripts));
+  }
+
+  // May not mix Cyrillic or Greek with another script
+  private boolean mixedGreekOrCyrillic(List<Character.UnicodeScript> scripts) {
+    return scripts.stream().anyMatch(uniqueScripts::contains);
+  }
+
+  // Latin script may be near universally combined with one other script
+  private boolean isValidLatin(List<Character.UnicodeScript> scripts) {
+    return scripts.size() <= 2 && scripts.stream().anyMatch(s -> s == LATIN);
+  }
+
+  // Han may be part of several script combinations
+  private boolean isValidHan(List<Character.UnicodeScript> scripts) {
+    return hanScripts.stream().anyMatch(h -> scripts.size() <= h.size() && h.containsAll(scripts));
+  }
+}

--- a/src/main/java/org/owasp/url/UrlClassifier.java
+++ b/src/main/java/org/owasp/url/UrlClassifier.java
@@ -42,6 +42,5 @@ public interface UrlClassifier {
    *     Pass {@link Diagnostic.Receiver#NULL} if you only need the result.
    * @return the classification of x
    */
-  public Classification apply(UrlValue x, Diagnostic.Receiver<? super UrlValue> r);
-
+  Classification apply(UrlValue x, Diagnostic.Receiver<? super UrlValue> r);
 }

--- a/src/test/java/org/owasp/url/AuthorityClassifierBuilderTest.java
+++ b/src/test/java/org/owasp/url/AuthorityClassifierBuilderTest.java
@@ -282,6 +282,22 @@ public final class AuthorityClassifierBuilderTest {
   }
 
   @Test
+  public void testPunycodeDomainSpoof() {
+    runTests(
+        AuthorityClassifiers.builder()
+            .host("google.com")
+            .build(),
+        ImmutableMap.of(
+            Classification.NOT_A_MATCH,
+            ImmutableList.of(
+                "https://googӏе.com/", // punycode mixed-script homograph of google
+                "https://xn--goog-y4d73g.com/", // ascii representation of the homograph,
+                "https://goog1e.com/" // single-script inelegant homograph
+            )
+        ));
+  }
+
+  @Test
   public void testSingleIntegerPortExclusion() {
     runCommonTestsWith(
         AuthorityClassifiers.builder()

--- a/src/test/java/org/owasp/url/PunycodeIdentifierTest.java
+++ b/src/test/java/org/owasp/url/PunycodeIdentifierTest.java
@@ -1,0 +1,134 @@
+// Copyright (c) 2019, Trent Miller
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+// Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+// Neither the name of the OWASP nor the names of its contributors may
+// be used to endorse or promote products derived from this software
+// without specific prior written permission.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+package org.owasp.url;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Testing for mixed scripts only
+ * https://unicode.org/cldr/utility/confusables.jsp is a useful resource for generating test strings
+ */
+@SuppressWarnings({ "javadoc", "static-method" })
+public final class PunycodeIdentifierTest {
+  private PunycodeIdentifier identifier;
+
+  @Before
+  public void before() {
+    identifier = PunycodeIdentifierBuilder.DEFAULT;
+  }
+
+  @Test
+  public void testEmptyString() {
+    assertFalse(identifier.isPotentialHomograph(""));
+  }
+
+  @Test
+  public void testSingleScript() {
+    assertFalse(identifier.isPotentialHomograph("google.com"));
+  }
+
+  @Test
+  public void testCyrillic() {
+    assertFalse(identifier.isPotentialHomograph("foo.Ьаг.com")); // Cryllic only homograph of 'bar'
+  }
+
+  @Test
+  public void testCyrillicTld() {
+    assertFalse(identifier.isPotentialHomograph("foo.bar.рф"));
+  }
+
+  @Test
+  public void testGreek() {
+    assertFalse(identifier.isPotentialHomograph("αρ.com")); // Greek only homograph of 'ap'
+  }
+
+  @Test
+  public void testLatinPlusCyrillic() {
+    assertTrue(identifier.isPotentialHomograph("gоogle.com")); // first 'o' is a Cyrillic small letter o, 043E
+  }
+
+  @Test
+  public void testLatinPlusGreek() {
+    assertTrue(identifier.isPotentialHomograph("gοogle.com")); // first 'o' is a Greek small omicron, 03BF
+  }
+
+  @Test
+  public void testLatinPlusOther() {
+    assertFalse(identifier.isPotentialHomograph("googוe.com")); // 'l' is replaced by the Hebrew letter vav, 05D5
+  }
+
+  @Test
+  public void testLatinPlusTwo() {
+    assertTrue(identifier.isPotentialHomograph("gಂgוe.com")); // 'oo' is replaced by single Kannada sign anusvara, 0CB2, and 'l' is replaced by Hebrew vav
+  }
+
+  @Test
+  public void testHanSimplified() {
+    assertFalse(identifier.isPotentialHomograph("买无.com")); // Han simplified characters for 'buy' and  'nothing'
+  }
+
+  @Test
+  public void testHanTraditional() {
+    assertFalse(identifier.isPotentialHomograph("買無.com")); // Han traditional characters for 'buy' and  'nothing'
+  }
+
+  @Test
+  public void testHanHiraganaKatakana() {
+    assertFalse(identifier.isPotentialHomograph("电おオ.com")); // Han character for electricity, Hiragana 304A, and Katakana 30AA
+  }
+
+  @Test
+  public void testHanBopomofo() {
+    assertFalse(identifier.isPotentialHomograph("买无ㄊ.com")); // Bopomofo 310A
+  }
+
+  @Test
+  public void testHanHangul() {
+    assertFalse(identifier.isPotentialHomograph("买无ᄊ.com")); // Hangul 110A
+  }
+
+  @Test
+  public void testHanBopomofoHangul() {
+    assertTrue(identifier.isPotentialHomograph("买无ㄊᄊ.com"));
+  }
+
+  @Test
+  public void testHanLatinHiraganaKatakana() {
+    assertFalse(identifier.isPotentialHomograph("cool-website-电おオ.com"));
+  }
+
+  @Test
+  public void testHanHiraganaKatakanaPlusOther() {
+    assertTrue(identifier.isPotentialHomograph("Ꮟ电おオ.com")); // Cherokee letter si, 13CF
+  }
+}

--- a/src/test/java/org/owasp/url/PunycodeIdentifierTest.java
+++ b/src/test/java/org/owasp/url/PunycodeIdentifierTest.java
@@ -59,12 +59,12 @@ public final class PunycodeIdentifierTest {
 
   @Test
   public void testCyrillic() {
-    assertFalse(identifier.isPotentialHomograph("foo.Ьаг.com")); // Cryllic only homograph of 'bar'
+    assertFalse(identifier.isPotentialHomograph("foo.Ьаг.com")); // Cyrillic only homograph of 'bar'
   }
 
   @Test
   public void testCyrillicTld() {
-    assertFalse(identifier.isPotentialHomograph("foo.bar.рф"));
+    assertFalse(identifier.isPotentialHomograph("foo.bar.рф")); // Cyrillic tld
   }
 
   @Test
@@ -108,23 +108,23 @@ public final class PunycodeIdentifierTest {
   }
 
   @Test
-  public void testHanBopomofo() {
-    assertFalse(identifier.isPotentialHomograph("买无ㄊ.com")); // Bopomofo 310A
+  public void testHanLatinHiraganaKatakana() {
+    assertFalse(identifier.isPotentialHomograph("cool-website-电おオ.com"));
   }
 
   @Test
-  public void testHanHangul() {
-    assertFalse(identifier.isPotentialHomograph("买无ᄊ.com")); // Hangul 110A
+  public void testHanLatinBopomofo() {
+    assertFalse(identifier.isPotentialHomograph("买无ㄊneat.com")); // Bopomofo 310A
+  }
+
+  @Test
+  public void testHanLatinHangul() {
+    assertFalse(identifier.isPotentialHomograph("买无greatᄊ.com")); // Hangul 110A
   }
 
   @Test
   public void testHanBopomofoHangul() {
-    assertTrue(identifier.isPotentialHomograph("买无ㄊᄊ.com"));
-  }
-
-  @Test
-  public void testHanLatinHiraganaKatakana() {
-    assertFalse(identifier.isPotentialHomograph("cool-website-电おオ.com"));
+    assertTrue(identifier.isPotentialHomograph("买无ㄊᄊ.com")); // Han simplified characters for 'buy' and  'nothing', Bopomofo 310A, and Hangul 110A
   }
 
   @Test


### PR DESCRIPTION
@mikesamuel , thank you for your earlier feedback in the Google Group regarding identifying potential punycode homograph attacks (https://groups.google.com/forum/#!topic/owasp-java-html-sanitizer-support/rI3V_Z6K6us). I've made this tentative PR to try and address the issue, but would like your feedback, and thought this might be a good way to advance the discussion.

I had a couple questions come up while working on this, that are probably worth discussing:
1) I'm not sure marking potential punycode homographs as invalid is the best way to go, since I'm not able confidentially identify them as such. After reading how other systems handle this attack vector, it looks like the primary responsibility for blocking homograph domains is on the TLD registrars. Other systems seem to rely on indicating a potential homograph to the user, or converting the questionable domain name to ASCII. How would you like to move forward with this solution?

2) I wasn't sure what the best way to include the punycode logic into this project, but it was starting to look like the punycode portion was substantial enough to warrant it's own class so I've broken it out. At the same time, it didn't seem like it should be a UrlClassifier itself, so I'd appreciate your thoughts on how to best structure it.

3) I tried following a builder pattern for inclusion of the PunycodeIdentifier and AuthorityClassifier's usage of it, but am open to any suggestions around it's implementation, or whether it needs a builder at all, since there are no additional properties at this time. The only properties I could think of might be worth including in the future would be to fail checks on suspicion of a homograph, and the option to auto-convert the string to ASCII if a suspicion is found. The latter option would probably be part of a separate function call if it was added.

4) Lastly, this is still an incomplete implementation, as I am only checking for mixed script domains, and not any same-script homographs that utilize. I think I would have to incorporate the codepoints in this document in order to do so, https://tools.ietf.org/html/rfc5892. This is something I could do at this time at the cost of some performance, or in a later iteration if the current implementation is found insufficient.

5) I bumped the JVM target to 8 so I could use Character.UnicodeScript, which requires 7, and streams, which requires 8. If we need to stay with 6 as the target, I can replace the usage of streams, but Character.UnicodeScript will be a bit more work. Let me know if this is going to be necessary.

Thanks again for your help on this, hopefully we can get it into useable shape.

![](https://media.giphy.com/media/vsGnvQD0ZcQco/giphy.gif)
